### PR TITLE
Update LaunchDarkly.Logging.NLog.csproj - Allow NLog v5

### DIFF
--- a/src/LaunchDarkly.Logging.NLog/LaunchDarkly.Logging.NLog.csproj
+++ b/src/LaunchDarkly.Logging.NLog/LaunchDarkly.Logging.NLog.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,]" />
-    <PackageReference Include="NLog" Version="[4.5.0,5.0.0)" />
+    <PackageReference Include="NLog" Version="[4.5.0,6.0.0)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
Resolves #3

BEGIN_COMMIT_OVERRIDE
feat: Update dependencies to allow using NLog v5.
END_COMMIT_OVERRIDE