### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
 
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full-length commit SHAs to prevent supply chain attacks.

Addresses findings from the [`third-party-action-not-pinned-to-commit-sha`](https://github.com/launchdarkly/semgrep-rules/blob/main/github-actions/third-party-action-not-pinned-to-commit-sha.yml) Semgrep rule.

## Test plan

- [ ] Verify CI passes with pinned action SHAs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the `uses:` reference for a third-party GitHub Action, with no application/runtime code impact. Primary risk is unexpected behavior if the pinned commit differs from the moving `v4` tag.
> 
> **Overview**
> Pins `google-github-actions/release-please-action` in `.github/workflows/release-please.yml` from `@v4` to a full commit SHA to improve supply-chain security and make releases reproducible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8eb0f4af3e83ba07a2cb762eb865578bb4e40a65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->