### PR TITLE
ci: add permissions to caller jobs and upgrade release-please-action to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
 
     steps:
-      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -26,6 +26,9 @@ jobs:
 
   call-workflow-publish:
     needs: release-please
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/publish.yml
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     with:
@@ -34,5 +37,7 @@ jobs:
 
   call-workflow-publish-docs:
     needs: release-please
+    permissions:
+      contents: write
     uses: ./.github/workflows/publish-docs.yml
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}


### PR DESCRIPTION
## Summary
Fixes Release Please `startup_failure` by adding explicit `permissions` to the `call-workflow-publish` and `call-workflow-publish-docs` caller jobs. Also migrates from archived `google-github-actions/release-please-action` to `googleapis/release-please-action` v5.

## Review & Testing Checklist for Human
- [ ] Verify the release-please workflow runs without startup_failure on next push to main
- [ ] Confirm the migration from google-github-actions to googleapis doesn't change behavior

### Notes
Same fix pattern as dotnet-core PR #241. The `google-github-actions/release-please-action` repo is archived; `googleapis/release-please-action` is the active successor.

Link to Devin session: https://app.devin.ai/sessions/54e32482848742c19ebf9c374efdc833
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts GitHub Actions release automation by changing the `release-please` action implementation and tightening/adding job-level permissions, which could impact release/publish execution if misconfigured.
> 
> **Overview**
> Updates the `release-please` workflow to use the maintained `googleapis/release-please-action` (v5) instead of the archived `google-github-actions` variant.
> 
> Adds explicit `permissions` to the reusable-workflow caller jobs (`call-workflow-publish` and `call-workflow-publish-docs`) so downstream `publish.yml`/docs publishing can run with the required `id-token`/`contents` scopes and avoid workflow startup failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66fb8852c3a8b27259642e4f933edae5e9d19247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->